### PR TITLE
Add configuration of subaccount sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Configure base AWS account IAM policies automatically using terraform.
 ## Bootstrap: first manual configuration
 
 Follow the instructions in [`BOOTSTRAP.md`](./BOOTSTRAP.md) to
-initalise your account.
+initalise your account or add new subaccounts.
 
 ## Allow usage only from whitelisted IPs
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Configure base AWS account IAM policies automatically using terraform.
 Follow the instructions in [`BOOTSTRAP.md`](./BOOTSTRAP.md) to
 initalise your account.
 
+## Allow usage only from whitelisted IPs
+
+This repository adds a policy to only allow access from a list whitelisted IPs.
+
+These IPs are configured in `pass keytwine/aws/allowed_ips.json` and it
+will also pick the current IP when running terraform apply.
+
+But if the IP is not added, currently the only way is login with the root account
+and edit the policy automatically.
+
 # Credits
 
 Based on: https://medium.com/@PatrikKarisch/automated-aws-account-initialization-with-terraform-and-onelogin-saml-sso-1301ff4851ab

--- a/aws-iam-user-init/main.tf
+++ b/aws-iam-user-init/main.tf
@@ -1,11 +1,3 @@
-variable "name" {
-  description = "Name of the user to create. Can be email"
-}
-
-variable "pgp_key" {
-  description = "GPG Public key in base64: gpg --export 12345678 | base64"
-}
-
 resource "aws_iam_user" "iam_user" {
   name = "${var.name}"
 }
@@ -32,14 +24,3 @@ export AWS_SECRET_ACCESS_KEY="$(echo "${aws_iam_access_key.iam_user.encrypted_se
 EOF
 }
 
-output "credentials_sh" {
-  value = "${data.template_file.credentials_sh.rendered}"
-}
-
-output "name" {
-  value = "${aws_iam_user.iam_user.name}"
-}
-
-output "arn" {
-  value = "${aws_iam_user.iam_user.arn}"
-}

--- a/aws-iam-user-init/outputs.tf
+++ b/aws-iam-user-init/outputs.tf
@@ -1,0 +1,11 @@
+output "credentials_sh" {
+  value = "${data.template_file.credentials_sh.rendered}"
+}
+
+output "name" {
+  value = "${aws_iam_user.iam_user.name}"
+}
+
+output "arn" {
+  value = "${aws_iam_user.iam_user.arn}"
+}

--- a/aws-iam-user-init/provider.tf
+++ b/aws-iam-user-init/provider.tf
@@ -1,4 +1,8 @@
 provider "aws" {
   region = "${var.aws_default_region}"
   allowed_account_ids = ["${var.account_id}"]
+  assume_role {
+    role_arn     = "arn:aws:iam::${var.account_id}:role/admin"
+    session_name = "terraform-aws-iam-user-init"
+  }
 }

--- a/aws-iam-user-init/provider.tf
+++ b/aws-iam-user-init/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region = "${var.aws_default_region}"
+  allowed_account_ids = ["${var.account_id}"]
+}

--- a/aws-iam-user-init/provider.tf
+++ b/aws-iam-user-init/provider.tf
@@ -1,8 +1,4 @@
 provider "aws" {
   region = "${var.aws_default_region}"
   allowed_account_ids = ["${var.account_id}"]
-  assume_role {
-    role_arn     = "arn:aws:iam::${var.account_id}:role/admin"
-    session_name = "terraform-aws-iam-user-init"
-  }
 }

--- a/aws-iam-user-init/variables.tf
+++ b/aws-iam-user-init/variables.tf
@@ -1,0 +1,15 @@
+variable "aws_default_region" {
+  default = "eu-west-1"
+}
+
+variable "name" {
+  description = "Name of the user to create. Can be email"
+}
+
+variable "pgp_key" {
+  description = "GPG Public key in base64: gpg --export 12345678 | base64"
+}
+
+variable "account_id" {
+  description = "AWS account ID where create the user"
+}

--- a/aws-root-account-init/policies.tf
+++ b/aws-root-account-init/policies.tf
@@ -87,6 +87,13 @@ data "template_file" "AssumeRoleTrustPolicyRootAccountWithMFA" {
           "aws:MultiFactorAuthPresent": "true"
         }
       }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${var.root_account_id}:role/admin"
+      },
+      "Action": "sts:AssumeRole"
     }
   ]
 }

--- a/aws-root-account-init/policies.tf
+++ b/aws-root-account-init/policies.tf
@@ -21,7 +21,7 @@ EOF
 
 resource "aws_iam_policy" "AssumeAdminRole" {
   name        = "AssumeAdminRole"
-  description = "Allow to assume admin in current and sub accounts account"
+  description = "Allow admins to assume any role in current and sub accounts accounts"
   path        = "/custom/"
 
   policy = <<EOF
@@ -35,7 +35,7 @@ resource "aws_iam_policy" "AssumeAdminRole" {
     "Resource": ${
       jsonencode(
         formatlist(
-          "arn:aws:iam::%s:role/admin",
+          "arn:aws:iam::%s:role/*",
           concat(list(var.root_account_id), var.sub_account_ids)
         )
       )

--- a/aws-root-account-init/provider.tf
+++ b/aws-root-account-init/provider.tf
@@ -1,8 +1,4 @@
 provider "aws" {
   region = "${var.aws_default_region}"
   allowed_account_ids = ["${var.root_account_id}"]
-  assume_role {
-    role_arn     = "arn:aws:iam::${var.root_account_id}:role/${var.terraform_assume_role}"
-    session_name = "terraform-aws-subaccount-init"
-  }
 }

--- a/aws-root-account-init/provider.tf
+++ b/aws-root-account-init/provider.tf
@@ -1,4 +1,8 @@
 provider "aws" {
   region = "${var.aws_default_region}"
   allowed_account_ids = ["${var.root_account_id}"]
+  assume_role {
+    role_arn     = "arn:aws:iam::${var.root_account_id}:role/${var.terraform_assume_role}"
+    session_name = "terraform-aws-subaccount-init"
+  }
 }

--- a/aws-root-account-init/roles.tf
+++ b/aws-root-account-init/roles.tf
@@ -14,6 +14,11 @@ resource "aws_iam_role_policy_attachment" "billing_RestrictToWhitelistedIPs" {
   policy_arn = "${aws_iam_policy.RestrictToWhitelistedIPs.arn}"
 }
 
+resource "aws_iam_role_policy_attachment" "billing_BillingAccess" {
+  role       = "${aws_iam_role.billing.name}"
+  policy_arn = "arn:aws:iam::aws:policy/job-function/Billing"
+}
+
 resource "aws_iam_role" "admin" {
   name               = "admin"
   description        = "Administrator: access to all resources and APIs. Occasional use."

--- a/aws-sub-account-init/main.tf
+++ b/aws-sub-account-init/main.tf
@@ -1,0 +1,3 @@
+resource "aws_iam_account_alias" "sub_account_alias" {
+  account_alias = "${var.sub_account_alias}"
+}

--- a/aws-sub-account-init/policies.tf
+++ b/aws-sub-account-init/policies.tf
@@ -1,0 +1,53 @@
+data "template_file" "AssumeRoleTrustPolicySubAccountWithMFA" {
+  template = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${var.root_account_id}:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+  vars {
+    root_account_id = "${var.root_account_id}"
+  }
+}
+
+resource "aws_iam_policy" "RestrictToWhitelistedIPs" {
+  name        = "RestrictToWhitelistedIPs"
+  description = "Only allow to operate from the Whitelisted IPs"
+  path        = "/custom/"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect" : "Deny",
+      "Resource" : [
+        "*"
+      ],
+      "Action" : [
+        "*"
+      ],
+      "Condition" : {
+        "NotIpAddress" : {
+          "aws:SourceIp" : ${jsonencode(var.allowed_ips)}
+        }
+      }
+    }
+  ]
+}
+EOF
+}

--- a/aws-sub-account-init/policies.tf
+++ b/aws-sub-account-init/policies.tf
@@ -14,6 +14,13 @@ data "template_file" "AssumeRoleTrustPolicySubAccountWithMFA" {
           "aws:MultiFactorAuthPresent": "true"
         }
       }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${var.root_account_id}:role/admin"
+      },
+      "Action": "sts:AssumeRole"
     }
   ]
 }

--- a/aws-sub-account-init/provider.tf
+++ b/aws-sub-account-init/provider.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+  assume_role {
+    role_arn     = "arn:aws:iam::${var.sub_account_id}:role/${var.terraform_assume_role}"
+    session_name = "terraform-aws-subaccount-init"
+  }
+}

--- a/aws-sub-account-init/roles.tf
+++ b/aws-sub-account-init/roles.tf
@@ -1,0 +1,31 @@
+resource "aws_iam_role" "admin" {
+  name               = "admin"
+  description        = "Administrator: access to all resources and APIs. Occasional use."
+  assume_role_policy = "${data.template_file.AssumeRoleTrustPolicySubAccountWithMFA.rendered}"
+}
+
+resource "aws_iam_role_policy_attachment" "admin_AdministratorAccess" {
+  role       = "${aws_iam_role.admin.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "admin_RestrictToWhitelistedIPs" {
+  role       = "${aws_iam_role.admin.name}"
+  policy_arn = "${aws_iam_policy.RestrictToWhitelistedIPs.arn}"
+}
+
+resource "aws_iam_role" "dev" {
+  name               = "dev"
+  description        = "Normal Developer: operate the account."
+  assume_role_policy = "${data.template_file.AssumeRoleTrustPolicySubAccountWithMFA.rendered}"
+}
+
+resource "aws_iam_role_policy_attachment" "dev_PowerUserAccess" {
+  role       = "${aws_iam_role.admin.name}"
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "dev_RestrictToWhitelistedIPs" {
+  role       = "${aws_iam_role.dev.name}"
+  policy_arn = "${aws_iam_policy.RestrictToWhitelistedIPs.arn}"
+}

--- a/aws-sub-account-init/variables.tf
+++ b/aws-sub-account-init/variables.tf
@@ -1,0 +1,25 @@
+variable "aws_default_region" {
+  default = "eu-west-1"
+}
+
+variable "root_account_id" {
+  description = "AWS account ID of the root account"
+}
+
+variable "sub_account_id" {
+  description = "AWS account ID of the sub-account"
+}
+
+variable "sub_account_alias" {
+  description = "AWS account alias to set for this sub account"
+}
+
+variable "terraform_assume_role" {
+  description = "Role to assume by terraform. Change it during bootstrap to define an alternate role created manually"
+  default = "admin"
+}
+
+variable "allowed_ips" {
+  description = "List of IPs allowed to operate with these accounts"
+  type        = "list"
+}

--- a/backend_config.tf
+++ b/backend_config.tf
@@ -4,6 +4,5 @@ terraform {
 	key            = "aws_iam_multiaccount"
 	region         = "eu-west-1"
 	dynamodb_table = "terraform_locks"
-	role_arn       = "arn:aws:iam::....:role/admin"
   }
 }

--- a/backend_config.tf
+++ b/backend_config.tf
@@ -4,5 +4,6 @@ terraform {
 	key            = "aws_iam_multiaccount"
 	region         = "eu-west-1"
 	dynamodb_table = "terraform_locks"
+	role_arn       = "arn:aws:iam::....:role/admin"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,33 +1,3 @@
-variable "company_name" {
-  default = "keytwine"
-}
-
-module "aws-root-account-init" {
-  source  = "./aws-root-account-init"
-
-  root_account_id = "${var.root_account_id}"
-  root_account_alias = "${var.company_name}-root"
-
-  sub_account_ids = "${var.sub_account_ids}"
-
-  interactive_users = [
-    "${module.hector_rivas_aws_dev_keytwine_com.name}",
-    "${module.hector_rivas_aws_admin_keytwine_com.name}"
-  ]
-  billing_users = [
-    "${module.hector_rivas_aws_dev_keytwine_com.name}",
-    "${module.hector_rivas_aws_admin_keytwine_com.name}"
-  ]
-  admin_users = [
-    "${module.hector_rivas_aws_admin_keytwine_com.name}"
-  ]
-  dev_users = [
-    "${module.hector_rivas_aws_dev_keytwine_com.name}"
-  ]
-
-  allowed_ips = "${var.allowed_ips}"
-}
-
 output "aws_console_url" {
   value = "https://${var.company_name}-root.signin.aws.amazon.com/console"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -4,8 +4,4 @@ provider "aws" {
     "${var.root_account_id}",
     "${var.sub_account_id_sandbox}"
   ]
-  assume_role {
-    role_arn     = "arn:aws:iam::${var.root_account_id}:role/admin"
-    session_name = "terraform-aws-iam-user-init"
-  }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,7 @@
 provider "aws" {
   region = "${var.aws_default_region}"
-  allowed_account_ids = ["${var.root_account_id}"]
+  allowed_account_ids = [
+    "${var.root_account_id}",
+    "${var.sub_account_id_sandbox}"
+  ]
 }

--- a/provider.tf
+++ b/provider.tf
@@ -4,4 +4,8 @@ provider "aws" {
     "${var.root_account_id}",
     "${var.sub_account_id_sandbox}"
   ]
+  assume_role {
+    role_arn     = "arn:aws:iam::${var.root_account_id}:role/admin"
+    session_name = "terraform-aws-iam-user-init"
+  }
 }

--- a/root_account.tf
+++ b/root_account.tf
@@ -4,7 +4,9 @@ module "aws-root-account-init" {
   root_account_id = "${var.root_account_id}"
   root_account_alias = "${var.company_name}-root"
 
-  sub_account_ids = "${var.sub_account_ids}"
+  sub_account_ids = [
+    "${var.sub_account_id_sandbox}"
+  ]
 
   interactive_users = [
     "${module.hector_rivas_aws_dev_keytwine_com.name}",

--- a/root_account.tf
+++ b/root_account.tf
@@ -1,0 +1,25 @@
+module "aws-root-account-init" {
+  source  = "./aws-root-account-init"
+
+  root_account_id = "${var.root_account_id}"
+  root_account_alias = "${var.company_name}-root"
+
+  sub_account_ids = "${var.sub_account_ids}"
+
+  interactive_users = [
+    "${module.hector_rivas_aws_dev_keytwine_com.name}",
+    "${module.hector_rivas_aws_admin_keytwine_com.name}"
+  ]
+  billing_users = [
+    "${module.hector_rivas_aws_dev_keytwine_com.name}",
+    "${module.hector_rivas_aws_admin_keytwine_com.name}"
+  ]
+  admin_users = [
+    "${module.hector_rivas_aws_admin_keytwine_com.name}"
+  ]
+  dev_users = [
+    "${module.hector_rivas_aws_dev_keytwine_com.name}"
+  ]
+
+  allowed_ips = "${var.allowed_ips}"
+}

--- a/run-terraform.sh
+++ b/run-terraform.sh
@@ -8,9 +8,7 @@ cd "$(dirname "$0")"
 current_ip="$(curl -qs ifconfig.co)"
 
 export TF_VAR_root_account_id="$(pass keytwine/aws/root/account_id)"
-export TF_VAR_sub_account_ids="[
-	\"$(pass keytwine/aws/sandbox/account_id)\"
-]"
+export TF_VAR_sub_account_id_sandbox="$(pass keytwine/aws/sandbox/account_id)"
 export TF_VAR_allowed_ips="$(
 	pass keytwine/aws/allowed_ips.json |
 		jq -r --arg current_ip "$current_ip" ' . += [$current_ip] | unique'

--- a/run-terraform.sh
+++ b/run-terraform.sh
@@ -5,11 +5,16 @@ cd "$(dirname "$0")"
 
 . ./scripts/common.sh
 
+current_ip="$(curl -qs ifconfig.co)"
+
 export TF_VAR_root_account_id="$(pass keytwine/aws/root/account_id)"
-export TF_VAR_allowed_ips="$(pass keytwine/aws/allowed_ips.json)"
 export TF_VAR_sub_account_ids="[
 	\"$(pass keytwine/aws/sandbox/account_id)\"
 ]"
+export TF_VAR_allowed_ips="$(
+	pass keytwine/aws/allowed_ips.json |
+		jq -r --arg current_ip "$current_ip" ' . += [$current_ip] | unique'
+)"
 
 case "${1:-}" in
   init-backend)

--- a/scripts/generate_TerraformInitRestricted_policy.sh
+++ b/scripts/generate_TerraformInitRestricted_policy.sh
@@ -17,7 +17,7 @@ case "$(uname -s)" in
 esac
 MY_IP="$(curl -qs ifconfig.co)"
 
-ACCOUNT_ID="${ACCOUNT_ID:=${-1}}"
+ACCOUNT_ID="${ACCOUNT_ID:-${1:-}}"
 if [ -z "${ACCOUNT_ID}" ]; then
   cat <<EOF
 Pass the root AWS account id as argument. You can get it in the console or running:
@@ -28,7 +28,7 @@ fi
 
 cat <<EOF
 #
-# TerraformInitRestricted: IAM policy with least privileged access which you use to initialise your account. Delete after usage.
+# TerraformInitRestricted: IAM policy with least privileged access which you use to initialise your root account. Delete after usage.
 #
 {
    "Version" : "2012-10-17",
@@ -105,4 +105,3 @@ cat <<EOF
    ]
 }
 EOF
-

--- a/subaccount_sandbox.tf
+++ b/subaccount_sandbox.tf
@@ -1,0 +1,13 @@
+module "aws-subaccount-account-init-sandbox" {
+  source  = "./aws-sub-account-init"
+
+  root_account_id = "${var.root_account_id}"
+  sub_account_id = "${var.sub_account_id_sandbox}"
+  sub_account_alias = "${var.company_name}-sandbox"
+
+  allowed_ips = "${var.allowed_ips}"
+
+  # Only used during bootstrap
+  # terraform_assume_role = "subaccount-admin"
+}
+

--- a/users.tf
+++ b/users.tf
@@ -1,7 +1,8 @@
 module "hector_rivas_aws_admin_keytwine_com" {
-  source  = "./aws-iam-user-init"
-  name    = "hector.rivas+aws.admin@keytwine.com"
-  pgp_key = "${var.hector_pgp_public_key}"
+  source     = "./aws-iam-user-init"
+  name       = "hector.rivas+aws.admin@keytwine.com"
+  pgp_key    = "${var.hector_pgp_public_key}"
+  account_id = "${var.root_account_id}"
 }
 
 output "hector_rivas_aws_admin_keytwine_com_credentials_sh" {
@@ -9,9 +10,10 @@ output "hector_rivas_aws_admin_keytwine_com_credentials_sh" {
 }
 
 module "hector_rivas_aws_dev_keytwine_com" {
-  source  = "./aws-iam-user-init"
-  name    = "hector.rivas+aws.dev@keytwine.com"
-  pgp_key = "${var.hector_pgp_public_key}"
+  source     = "./aws-iam-user-init"
+  name       = "hector.rivas+aws.dev@keytwine.com"
+  pgp_key    = "${var.hector_pgp_public_key}"
+  account_id = "${var.root_account_id}"
 }
 
 output "hector_rivas_aws_dev_keytwine_com_credentials_sh" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,9 +10,8 @@ variable "root_account_id" {
     description = "Root account id"
 }
 
-variable "sub_account_ids" {
-    description = "AWS Sub account ids"
-    type        = "list"
+variable "sub_account_id_sandbox" {
+    description = "AWS Sub account id for sandbox account"
 }
 
 # gpg --export -a 2EA619ED

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,7 @@
+variable "company_name" {
+  default = "keytwine"
+}
+
 variable "aws_default_region" {
     default = "eu-west-1"
 }


### PR DESCRIPTION
Add the configuration of the subaccount with federated assume role.

For the sub-accounts, we allow any user with a MFA token to assume
the roles, and we control who access which role in the root account.

We add the special case for the role/admin in the root account, that
can assume any role without MFA token. This allows run terraform with
assume role to configure the subaccounts.