### PR TITLE
Automate update of whitelisted IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ This repository adds a policy to only allow access from a list whitelisted IPs.
 These IPs are configured in `pass keytwine/aws/allowed_ips.json` and it
 will also pick the current IP when running terraform apply.
 
-But if the IP is not added, currently the only way is login with the root account
-and edit the policy automatically.
+If the IP is not alllowed, you can load the user AWS admi ncredentials
+and run `./scripts/whitelist_current_ip.sh`.  For example, using the
+[`awssts`](https://github.com/keymon/aws_key_management/blob/master/awssts.sh)
+tool:
+
+    awssts user:hector.rivas+admin@keytwine \
+          ./scripts/whitelist_current_ip.sh
 
 # Credits
 

--- a/aws-ip-restriction/outputs.tf
+++ b/aws-ip-restriction/outputs.tf
@@ -1,0 +1,3 @@
+output "RestrictToWhitelistedIPs_arn" {
+  value = "${aws_iam_policy.RestrictToWhitelistedIPs.arn}"
+}

--- a/aws-ip-restriction/policies.tf
+++ b/aws-ip-restriction/policies.tf
@@ -1,0 +1,70 @@
+resource "aws_iam_policy" "RestrictToWhitelistedIPs" {
+  name        = "RestrictToWhitelistedIPs"
+  description = "Only allow to operate from the Whitelisted IPs"
+  path        = "/custom/"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect" : "Deny",
+      "NotResource" : [
+        "${aws_iam_role.whitelist_ips_updater.arn}"
+      ],
+      "NotAction" : [
+        "sts:AssumeRole"
+      ],
+      "Condition" : {
+        "NotIpAddress" : {
+          "aws:SourceIp" : ${jsonencode(var.allowed_ips)}
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "AllowUpdateRestrictToWhitelistedIPs" {
+  name        = "AllowUpdateRestrictToWhitelistedIPs"
+  description = "Allow to update the RestrictToWhitelistedIPs policy"
+  path        = "/custom/"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect" : "Allow",
+      "Resource" : [
+        "${aws_iam_policy.RestrictToWhitelistedIPs.arn}"
+      ],
+      "Action" : [
+        "iam:GetPolicy",
+        "iam:GetPolicyVersion",
+        "iam:ListPolicyVersions",
+        "iam:DeletePolicyVersion",
+        "iam:CreatePolicyVersion"
+      ],
+      "Condition": {
+        "StringLike": {
+          "aws:userid": [
+            "*:whitelist_ips_updater+$${aws:SourceIp}"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:role/whitelist_ips_updater"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/aws-ip-restriction/roles.tf
+++ b/aws-ip-restriction/roles.tf
@@ -1,0 +1,37 @@
+resource "aws_iam_role" "whitelist_ips_updater" {
+  name               = "whitelist_ips_updater"
+  description        = "Role allowed to update the Policy with whitelisted IPs"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${var.root_account_id}:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${var.root_account_id}:role/whitelist_ips_updater"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "whitelist_ips_updater_AllowUpdateRestrictToWhitelistedIPs" {
+  role       = "${aws_iam_role.whitelist_ips_updater.name}"
+  policy_arn = "${aws_iam_policy.AllowUpdateRestrictToWhitelistedIPs.arn}"
+}
+
+

--- a/aws-ip-restriction/variables.tf
+++ b/aws-ip-restriction/variables.tf
@@ -1,0 +1,8 @@
+variable "allowed_ips" {
+  description = "List of IPs allowed to operate with these accounts"
+  type        = "list"
+}
+
+variable "root_account_id" {
+  description = "AWS account ID of the root account where the users are defined"
+}

--- a/aws-root-account-init/iam_groups.tf
+++ b/aws-root-account-init/iam_groups.tf
@@ -41,7 +41,7 @@ resource "aws_iam_group_membership" "interactive_users" {
 
 resource "aws_iam_group_policy_attachment" "interactive_users_RestrictToWhitelistedIPs" {
   group      = "${aws_iam_group.interactive_users.name}"
-  policy_arn = "${aws_iam_policy.RestrictToWhitelistedIPs.arn}"
+  policy_arn = "${module.aws-ip-restriction.RestrictToWhitelistedIPs_arn}"
 }
 
 # Group permissions

--- a/aws-root-account-init/ip_restriction.tf
+++ b/aws-root-account-init/ip_restriction.tf
@@ -1,0 +1,5 @@
+module "aws-ip-restriction" {
+  source          = "../aws-ip-restriction"
+  allowed_ips     = "${var.allowed_ips}"
+  root_account_id = "${var.root_account_id}"
+}

--- a/aws-root-account-init/policies.tf
+++ b/aws-root-account-init/policies.tf
@@ -173,31 +173,3 @@ resource "aws_iam_policy" "SelfManageAccount" {
 }
 EOF
 }
-
-resource "aws_iam_policy" "RestrictToWhitelistedIPs" {
-  name        = "RestrictToWhitelistedIPs"
-  description = "Only allow to operate from the Whitelisted IPs"
-  path        = "/custom/"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect" : "Deny",
-      "Resource" : [
-        "*"
-      ],
-      "Action" : [
-        "*"
-      ],
-      "Condition" : {
-        "NotIpAddress" : {
-          "aws:SourceIp" : ${jsonencode(var.allowed_ips)}
-        }
-      }
-    }
-  ]
-}
-EOF
-}

--- a/aws-root-account-init/provider.tf
+++ b/aws-root-account-init/provider.tf
@@ -2,3 +2,4 @@ provider "aws" {
   region = "${var.aws_default_region}"
   allowed_account_ids = ["${var.root_account_id}"]
 }
+data "aws_caller_identity" "current" {}

--- a/aws-root-account-init/roles.tf
+++ b/aws-root-account-init/roles.tf
@@ -11,7 +11,7 @@ resource "aws_iam_role_policy_attachment" "billing_AssumeBillingRole" {
 
 resource "aws_iam_role_policy_attachment" "billing_RestrictToWhitelistedIPs" {
   role       = "${aws_iam_role.billing.name}"
-  policy_arn = "${aws_iam_policy.RestrictToWhitelistedIPs.arn}"
+  policy_arn = "${module.aws-ip-restriction.RestrictToWhitelistedIPs_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "billing_BillingAccess" {
@@ -27,7 +27,7 @@ resource "aws_iam_role" "admin" {
 
 resource "aws_iam_role_policy_attachment" "admin_AssumeAdminRole" {
   role       = "${aws_iam_role.admin.name}"
-  policy_arn = "${aws_iam_policy.AssumeAdminRole.arn}"
+  policy_arn = "${module.aws-ip-restriction.RestrictToWhitelistedIPs_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "admin_AdministratorAccess" {
@@ -37,7 +37,7 @@ resource "aws_iam_role_policy_attachment" "admin_AdministratorAccess" {
 
 resource "aws_iam_role_policy_attachment" "admin_RestrictToWhitelistedIPs" {
   role       = "${aws_iam_role.admin.name}"
-  policy_arn = "${aws_iam_policy.RestrictToWhitelistedIPs.arn}"
+  policy_arn = "${module.aws-ip-restriction.RestrictToWhitelistedIPs_arn}"
 }
 
 resource "aws_iam_role" "dev" {
@@ -53,5 +53,5 @@ resource "aws_iam_role_policy_attachment" "dev_AssumeSubAccountDevRole" {
 
 resource "aws_iam_role_policy_attachment" "dev_RestrictToWhitelistedIPs" {
   role       = "${aws_iam_role.dev.name}"
-  policy_arn = "${aws_iam_policy.RestrictToWhitelistedIPs.arn}"
+  policy_arn = "${module.aws-ip-restriction.RestrictToWhitelistedIPs_arn}"
 }

--- a/aws-sub-account-init/ip_restriction.tf
+++ b/aws-sub-account-init/ip_restriction.tf
@@ -1,0 +1,5 @@
+module "aws-ip-restriction" {
+  source          = "../aws-ip-restriction"
+  allowed_ips     = "${var.allowed_ips}"
+  root_account_id = "${var.root_account_id}"
+}

--- a/aws-sub-account-init/policies.tf
+++ b/aws-sub-account-init/policies.tf
@@ -30,31 +30,3 @@ EOF
     root_account_id = "${var.root_account_id}"
   }
 }
-
-resource "aws_iam_policy" "RestrictToWhitelistedIPs" {
-  name        = "RestrictToWhitelistedIPs"
-  description = "Only allow to operate from the Whitelisted IPs"
-  path        = "/custom/"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect" : "Deny",
-      "Resource" : [
-        "*"
-      ],
-      "Action" : [
-        "*"
-      ],
-      "Condition" : {
-        "NotIpAddress" : {
-          "aws:SourceIp" : ${jsonencode(var.allowed_ips)}
-        }
-      }
-    }
-  ]
-}
-EOF
-}

--- a/aws-sub-account-init/roles.tf
+++ b/aws-sub-account-init/roles.tf
@@ -11,7 +11,7 @@ resource "aws_iam_role_policy_attachment" "admin_AdministratorAccess" {
 
 resource "aws_iam_role_policy_attachment" "admin_RestrictToWhitelistedIPs" {
   role       = "${aws_iam_role.admin.name}"
-  policy_arn = "${aws_iam_policy.RestrictToWhitelistedIPs.arn}"
+  policy_arn = "${module.aws-ip-restriction.RestrictToWhitelistedIPs_arn}"
 }
 
 resource "aws_iam_role" "dev" {
@@ -27,5 +27,5 @@ resource "aws_iam_role_policy_attachment" "dev_PowerUserAccess" {
 
 resource "aws_iam_role_policy_attachment" "dev_RestrictToWhitelistedIPs" {
   role       = "${aws_iam_role.dev.name}"
-  policy_arn = "${aws_iam_policy.RestrictToWhitelistedIPs.arn}"
+  policy_arn = "${module.aws-ip-restriction.RestrictToWhitelistedIPs_arn}"
 }

--- a/scripts/whitelist_current_ip.sh
+++ b/scripts/whitelist_current_ip.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# Add the current IP to the list of whitelisted IPs for a policy
+#
+set -e -u -o pipefail
+
+ROOT_ACCOUNT_ID="$(pass keytwine/aws/root/account_id)"
+
+ACCOUNT_IDS="
+  $(pass keytwine/aws/gfl/account_id)
+  $(pass keytwine/aws/root/account_id)
+  $(pass keytwine/aws/sandbox/account_id)
+"
+WHITELIST_IP_POLICY_UPDATE_ROLE=whitelist_ips_updater
+WHITELIST_IP_POLICY_NAME=custom/RestrictToWhitelistedIPs
+
+add_ip_to_policy() {
+  local ipaddress="$1"
+  jq \
+    --arg ipaddress "${ipaddress}" \
+    '.Statement[0].Condition.NotIpAddress."aws:SourceIp" |= ((.+ [$ipaddress]) | unique)'
+}
+
+get_sts_token() {
+  local account_id="${1}"
+  local role_name="${2}"
+  local session_name="${3}"
+  local role_arn="arn:aws:iam::${account_id}:role/${role_name}"
+  local duration=900
+
+  local caller_arn="$(aws sts get-caller-identity --query Arn --output text)"
+
+  # Ask for MFA if the caller is a user. Skip for assumed roles.
+  if echo "${caller_arn}" | grep -qe "arn:aws:iam::[0-9]\+:user/.*"; then
+    local token_arn="${caller_arn/:user/:mfa}"
+    local user_name="${caller_arn#*/}"
+    read -p "MFA Token code for ${caller_arn}: " token
+  fi
+
+  aws sts \
+    assume-role \
+    --role-arn "${role_arn}" \
+    --role-session-name "${session_name}" \
+    --duration-seconds "${duration}" \
+    ${token:+--serial-number "${token_arn}" --token-code "${token}"} \
+    --output text \
+    --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' \
+    | \
+      awk '{ print "export AWS_ACCESS_KEY_ID=\"" $1 "\"\n" "export AWS_SECRET_ACCESS_KEY=\"" $2 "\"\n" "export AWS_SESSION_TOKEN=\"" $3 "\"" }'
+}
+
+get_policy() {
+  local account_id="${1}"
+  local policy_name="${2}"
+  local policy_arn="arn:aws:iam::${account_id}:policy/${policy_name}"
+  policy_version=$(
+    aws iam get-policy \
+      --policy-arn "${policy_arn}" \
+      --output text \
+      --query 'Policy.DefaultVersionId'
+  )
+  aws iam get-policy-version \
+    --policy-arn "${policy_arn}" \
+    --version-id "${policy_version}" \
+    --query 'PolicyVersion.Document'
+}
+
+delete_oldest_policy_version() {
+  local account_id="${1}"
+  local policy_name="${2}"
+  local policy_arn="arn:aws:iam::${account_id}:policy/${policy_name}"
+  oldest_version="$(
+    aws iam list-policy-versions \
+      --policy-arn "${policy_arn}" |
+      jq -r '.Versions | sort_by(.CreateDate) | map(select(.IsDefaultVersion == false)) | .[0].VersionId'
+  )"
+  if [ ! -z "${oldest_version}" ] && [ "${oldest_version}" != "null" ]; then
+    echo "Deleting old version of policy ${policy_arn}:${oldest_version}"
+    aws iam delete-policy-version \
+      --policy-arn "${policy_arn}" \
+      --version-id "${oldest_version}"
+  fi
+}
+
+update_policy() {
+  local account_id="${1}"
+  local policy_name="${2}"
+  local policy_document="${3}"
+  local policy_arn="arn:aws:iam::${account_id}:policy/${policy_name}"
+  delete_oldest_policy_version "${account_id}" "${policy_name}"
+  aws iam create-policy-version \
+    --policy-arn "${policy_arn}" \
+    --policy-document "${policy_document}" \
+    --set-as-default > /dev/null
+}
+
+add_ip_to_policy_in_account() {
+  (
+    local account_id="${1}"
+    local role_name="${2}"
+    local policy_name="${3}"
+    local current_ip="${4}"
+
+    echo "Adding IP ${current_ip} in policy ${policy_name} for account ${account_id}"
+
+    # Retrieve new tokens for each subaccount
+    eval $(get_sts_token "${account_id}" "${role_name}" "whitelist_ips_updater+${current_ip}")
+
+    old_policy_document="$(get_policy "${account_id}" "${policy_name}" | jq -cS .)"
+    updated_policy_document="$(echo "${old_policy_document}" | add_ip_to_policy "${current_ip}" | jq -cS .)"
+
+    if [ "${old_policy_document}" != "${updated_policy_document}" ]; then
+      update_policy "${account_id}" "${policy_name}" "${updated_policy_document}"
+      echo "Policy updated to add IP ${current_ip}."
+    else
+      echo "Policy is the same. Is IP ${current_ip} already added?. Skipping."
+      echo "Curreny policy:"
+      echo "${old_policy_document}" | jq .
+    fi
+  )
+}
+
+current_ip="$(curl -qs ifconfig.co)"
+
+# Retrieve first token with MFA auth for the root account
+eval $(get_sts_token "${ROOT_ACCOUNT_ID}" "${WHITELIST_IP_POLICY_UPDATE_ROLE}" "whitelist_ips_updater+${current_ip}")
+
+for account_id in ${ACCOUNT_IDS}; do
+  add_ip_to_policy_in_account "${account_id}" \
+    "${WHITELIST_IP_POLICY_UPDATE_ROLE}" \
+    "${WHITELIST_IP_POLICY_NAME}" \
+    "${current_ip}"
+done


### PR DESCRIPTION
We want to easily add the current IPs to the policy that blocks
AWS API access to whitelisted IPs, even from an IP that is blocked.

Allow anything to modify a policy is risky, as we cannot control
what is added to the policy. Because that we want to ensure
that such operation requires at least MFA, and that minimises
the possibility of access the account with leaked API creds.

For this we would create a special role `whitelist_ips_updater`,
which can:

 - update the RestrictToWhitelistedIPs policy, to add new IPs.
 - be assumed from any user with MFA token. Note that only admin
   can explicitly assume it anyway.
 - be assumed from the role `whitelist_ips_updater`. This is to
   allow change the policy in multiple accounts but with only
   input the MFA once.

The RestrictToWhitelistedIPs would now block all the operations,
except assume the role `whitelist_ips_updater`.

We move all the policies, common for root and sub accounts to a
dedicated submodule.

To actually add the IP we wrote a script that would assume
a special role using MFA token, and then iterate across each
account to read the policy & inject the current IP
retrieved from http://ifconfig.co.

One does not actually update the policy, but create a new default
version. whenever we add a new policy version, we delete the oldest
non default version to be sure we do not add more than the allowed
versions.

To use the script, you must load the user credentials and run it.
For example, using my `awssts` tool[1]:

   awssts user:hector.rivas+admin@keytwine \
      ./scripts/whitelist_current_ip.sh

[1] https://github.com/keymon/aws_key_management/blob/master/awssts.sh